### PR TITLE
Fix stripping of python libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,26 @@ PI_VERSION=${VERSION}
 
 info:
 	@echo "buildrpm          - build a new RPM from python package index"
+	@echo "signrpm           - sign the RPMs"
 	@echo "fill-devel-repo   - put the newly built packages into the local DEVEL repo"
 	@echo "fill-release-repo - put the newly built packages into the local release repo"
 	@echo "make-repo         - fetch existing repo and build a new local repository with new packages"
 	@echo "push-repo         - push the devel and productive repo to lancelot"
 
-buildrpm:
-	PI_VERSION=${PI_VERSION} rpmbuild --define "_topdir `pwd`" --sign -ba SPECS/privacyidea.spec
-	PI_VERSION=${PI_VERSION} rpmbuild --define "_topdir `pwd`" --sign -ba SPECS/privacyidea-server.spec
+buildrpm: buildpi buildradius buildoracle
+
+buildpi:
+	PI_VERSION=${PI_VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea.spec
+	PI_VERSION=${PI_VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-server.spec
 
 buildradius:
-	PI_VERSION=${PI_VERSION} rpmbuild --define "_topdir `pwd`" --sign -ba SPECS/privacyidea-radius.spec
+	PI_VERSION=${PI_VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-radius.spec
 
 buildoracle:
-	rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-cx-oracle.spec 
+	rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-cx-oracle.spec
+
+signrpm: buildrpm
+	find RPMS/ -name *.rpm -exec 'rpmsign' '--addsign' '{}' ';'
 
 fill-release-repo:
 	mkdir -p repository/centos/7/

--- a/SPECS/privacyidea-cx-oracle.spec
+++ b/SPECS/privacyidea-cx-oracle.spec
@@ -16,7 +16,7 @@ URL:            https://www.privacyidea.org
 Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 BuildArch:      x86_64
 
-BuildRequires: libxml2-devel, freetype-devel, python-devel, libxslt-devel, zlib-devel, openssl-devel
+BuildRequires: python-virtualenv
 Requires:      privacyidea
 
 #Source0:       %{source0}

--- a/SPECS/privacyidea-radius.spec
+++ b/SPECS/privacyidea-radius.spec
@@ -16,7 +16,7 @@ URL:            https://www.privacyidea.org
 Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 BuildArch:      noarch
 
-BuildRequires: libxml2-devel, freetype-devel, libxslt-devel, zlib-devel, openssl-devel
+BuildRequires: git
 Requires:      freeradius, freeradius-perl, perl-LWP-Protocol-https, freeradius-utils
 
 
@@ -41,7 +41,7 @@ Requires:      freeradius, freeradius-perl, perl-LWP-Protocol-https, freeradius-
 # Create git repo
 mkdir -p $RPM_BUILD_ROOT/git
 git clone %{gitsource} $RPM_BUILD_ROOT/git
-cd $RPM_BUILD_ROOT/git; git checkout v%{version}
+(cd $RPM_BUILD_ROOT/git; git checkout v%{version})
 mkdir -p $RPM_BUILD_ROOT/usr/lib/privacyidea
 cp $RPM_BUILD_ROOT/git/privacyidea_radius.pm $RPM_BUILD_ROOT/usr/lib/privacyidea/privacyidea_radius.pm
 mkdir -p $RPM_BUILD_ROOT/etc/privacyidea

--- a/SPECS/privacyidea-server.spec
+++ b/SPECS/privacyidea-server.spec
@@ -1,6 +1,6 @@
 %define source_name privacyIDEA
 %define name privacyidea-server
-%define version %{getenv:PI_VERSION} 
+%define version %{getenv:PI_VERSION}
 %define unmangled_version %{version}
 %define unmangled_version %{version}
 %define release 1
@@ -16,7 +16,7 @@ Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 BuildArch:      x86_64
 Requires:	privacyidea, mariadb-server, httpd, mod_wsgi, mod_ssl, rng-tools, psmisc
 
-BuildRequires: libxml2-devel, freetype-devel, python-devel, libxslt-devel, zlib-devel, openssl-devel
+BuildRequires: curl
 
 %description
  privacyIDEA: identity, multifactor authentication, authorization.
@@ -78,7 +78,7 @@ if [ -z "$(grep ^SQLALCHEMY_DATABASE_URI /etc/privacyidea/pi.cfg)" ]; then
             mysql -e "create database pi;" || true
 	else
 	    echo "Database already exists. Good."
-	fi 
+	fi
         mysql -e "grant all privileges on pi.* to 'pi'@'localhost' identified by '$NPW';"
         echo "SQLALCHEMY_DATABASE_URI = 'pymysql://pi:$NPW@localhost/pi'" >> /etc/privacyidea/pi.cfg
 	pi-manage createdb 2>&1 || true > /dev/null

--- a/SPECS/privacyidea.spec
+++ b/SPECS/privacyidea.spec
@@ -1,11 +1,12 @@
 %define source_name privacyIDEA
 %define name privacyidea
-%define version %{getenv:PI_VERSION} 
+%define version %{getenv:PI_VERSION}
 %define unmangled_version %{version}
 %define unmangled_version %{version}
 %define release 2
-# Skip the postinstall scripts, otherwise Pillow will fail.
-%global __os_install_post %{nil}
+# Somehow stripping the '.comment' section from the Pillow libraries breaks the strip-tool,
+# so we skip stripping and byte-compile in the postinstall scripts, otherwise Pillow will fail.
+%global __os_install_post %(echo '%{__os_install_post}' | sed -re 's!/usr/lib[^[:space:]]*/((brp-python-bytecompile)|(brp-strip-comment-note))[[:space:]].*$!!g')
 Name:           %{name}
 Version:        %{version}
 Release:        %{release}%{?dist}
@@ -18,7 +19,7 @@ Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 BuildArch:      x86_64
 AutoReqProv:	no
 
-BuildRequires: libxml2-devel, freetype-devel, python-devel, libxslt-devel, zlib-devel, openssl-devel, python-virtualenv, gcc, createrepo
+BuildRequires: python-virtualenv
 
 %description
  privacyIDEA: identity, multifactor authentication, authorization.
@@ -40,9 +41,9 @@ rm -fr /opt/privacyidea
 virtualenv /opt/privacyidea
 source /opt/privacyidea/bin/activate
 pip install --upgrade pip
+pip install -r https://raw.githubusercontent.com/privacyidea/privacyidea/v%{version}/requirements.txt
 pip install privacyidea==%{version}
 pip install pymysql_sa
-pip install -r /opt/privacyidea/lib/privacyidea/requirements.txt
 # No Auth Modules in the base package
 rm -fr /opt/privacyidea/lib/python2.7/site-packages/authmodules
 rm -fr /opt/privacyidea/lib/privacyidea/authmodules

--- a/SPECS/privacyidea.spec
+++ b/SPECS/privacyidea.spec
@@ -3,7 +3,7 @@
 %define version %{getenv:PI_VERSION}
 %define unmangled_version %{version}
 %define unmangled_version %{version}
-%define release 2
+%define release 1
 # Somehow stripping the '.comment' section from the Pillow libraries breaks the strip-tool,
 # so we skip stripping and byte-compile in the postinstall scripts, otherwise Pillow will fail.
 %global __os_install_post %(echo '%{__os_install_post}' | sed -re 's!/usr/lib[^[:space:]]*/((brp-python-bytecompile)|(brp-strip-comment-note))[[:space:]].*$!!g')
@@ -42,7 +42,7 @@ virtualenv /opt/privacyidea
 source /opt/privacyidea/bin/activate
 pip install --upgrade pip
 pip install -r https://raw.githubusercontent.com/privacyidea/privacyidea/v%{version}/requirements.txt
-pip install privacyidea==%{version}
+pip install git+https://github.com/privacyidea/privacyidea.git@v%{version}
 pip install pymysql_sa
 # No Auth Modules in the base package
 rm -fr /opt/privacyidea/lib/python2.7/site-packages/authmodules


### PR DESCRIPTION
- Remove the stripping of libraries in post install macros.
- Remove several build dependencies, they are not needed any more.
- During setup of the virtualenv, first install the pinned requirements
  from github for this version, then install privacyIDEA from pypi.
- Split up building and signing of the RPM packages.