### PR TITLE
Activate the perl module

### DIFF
--- a/SPECS/privacyidea-radius.spec
+++ b/SPECS/privacyidea-radius.spec
@@ -54,6 +54,12 @@ cp $RPM_SOURCE_DIR/privacyidea-mods-perl $RPM_BUILD_ROOT/etc/raddb/mods-availabl
 rm $RPM_BUILD_ROOT/git -fr
 
 
+%post
+# Activate the piperl RADIUS module
+cd /etc/raddb/mods-enabled/
+ln -s ../mods-available/piperl .
+systemctl restart radiusd
+
 %clean
 
 %files


### PR DESCRIPTION
After installing the privacyidea-radius package we
also activate the "piperl" module which is needed
in our default RADIUS configuration.

Closes #4