### PR TITLE
Add dependency for perl-URI-Encode

### DIFF
--- a/SPECS/privacyidea-radius.spec
+++ b/SPECS/privacyidea-radius.spec
@@ -18,7 +18,7 @@ Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 BuildArch:      noarch
 
 BuildRequires:  git
-Requires:       freeradius, freeradius-perl, perl-LWP-Protocol-https, freeradius-utils
+Requires:       freeradius, freeradius-perl, perl-LWP-Protocol-https, freeradius-utils, perl-URI-Encode
 #Requires:       epel-release
 #Requires:       perl-Data-Dump
 #Requires:       perl-Config-IniFiles


### PR DESCRIPTION
To be able to work with special characters in privacyIDEA 3.6.1
we need to encode the parameters user and pass.
To do so, we need to add the package perl-URI-Encode.