### PR TITLE
fix softlink creation

### DIFF
--- a/SPECS/privacyidea-radius.spec
+++ b/SPECS/privacyidea-radius.spec
@@ -63,7 +63,7 @@ install %{SOURCE2} $RPM_BUILD_ROOT/etc/raddb/mods-available/piperl
 %post
 # Activate the piperl RADIUS module
 cd /etc/raddb/mods-enabled/
-ln -s ../mods-available/piperl .
+ln -sf ../mods-available/piperl .
 systemctl restart radiusd
 
 %clean


### PR DESCRIPTION
Warning during Radius package update that a softlink cannot be written because it already exists.

The installation runs successfully. 

Fix removes the softlink before setting a new one.
ln -sf ../mods-available/piperl .