### PR TITLE
Change WSGI settings

### DIFF
--- a/SOURCES/privacyidea.conf
+++ b/SOURCES/privacyidea.conf
@@ -24,6 +24,7 @@ SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
 
 WSGIDaemonProcess privacyidea processes=1 threads=15 display-name=%{GROUP} user=privacyidea
 WSGIProcessGroup privacyidea
+WSGIApplicationGroup %{GLOBAL}
 WSGIPassAuthorization On
 WSGIScriptAlias / /etc/privacyidea/privacyideaapp.wsgi
 SSLEngine On


### PR DESCRIPTION
Add the setting `WSGIApplicationGroup %{GLOBAL}` to avoid deadlocks when using the MSCAConnector (See
https://github.com/privacyidea/privacyidea/issues/3506).