### PR TITLE
Building adjustment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # variable for holding OS level RedHat-based Linux Distributions
-        OS=${shell grep VERSION_ID= /etc/os-release | cut -d = -f 2| cut -c 2}
+	OS=${shell grep VERSION_ID= /etc/os-release | cut -d = -f 2| cut -c 2}
 
 info:
 	@echo "buildrpm          - build a new RPM from a GitHub tag"
@@ -15,18 +15,18 @@ info:
 
 buildrpm:
 ifndef VERSION
-        $(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/privacyidea/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
-        @echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
+	$(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/privacyidea/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
+	@echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
 endif
-        PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea.spec
-        PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-server.spec
+	PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea.spec
+	PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-server.spec
 
 buildradius:
 ifndef VERSION
-        $(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/FreeRADIUS/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
-        @echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
+	$(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/FreeRADIUS/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
+	@echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
 endif
-        PI_VERSION=$(VERSION) rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-radius.spec
+	PI_VERSION=$(VERSION) rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-radius.spec
 
 buildselinux:
 	rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-selinux.spec
@@ -35,15 +35,15 @@ buildpamselinux:
 	rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-pam-selinux.spec
 
 signrpm: buildrpm
-        find RPMS/ -name *.rpm -exec 'rpmsign' '--addsign' '{}' ';'
+	find RPMS/ -name *.rpm -exec 'rpmsign' '--addsign' '{}' ';'
 
 fill-release-repo: signrpm
-        mkdir -p repository/centos/$(OS)/
-        cp -r RPMS/* repository/centos/$(OS)/
+	mkdir -p repository/centos/$(OS)/
+	cp -r RPMS/* repository/centos/$(OS)/
 
 fill-devel-repo: signrpm
-        mkdir -p repository/centos-devel/$(OS)/
-        cp -r RPMS/* repository/centos-devel/$(OS)/
+	mkdir -p repository/centos-devel/$(OS)/
+	cp -r RPMS/* repository/centos-devel/$(OS)/
 
 make-repo:
 	# Fetch old packages

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-# variable for holding OS level centos/rocky/rhel 7/8/9
-	OS=${shell grep VERSION_ID= /etc/os-release | cut -d = -f 2| cut -c 2}
+# variable for holding OS level RedHat-based Linux Distributions
+        OS=${shell grep VERSION_ID= /etc/os-release | cut -d = -f 2| cut -c 2}
 
 info:
 	@echo "buildrpm          - build a new RPM from a GitHub tag"
 	@echo "buildradius       - build a new RPM for the radius plugin"
 	@echo "buildselinux      - build a new RPM with Selinux Policy for privacyidea base on centos"
+	@echo "buildpamselinux   - build a new RPM with Selinux Policy for privacyIDEA PAM-module"
 	@echo "signrpm           - sign all RPMs"
 	@echo "fill-devel-repo   - put the newly built packages into the local DEVEL repo"
 	@echo "fill-release-repo - put the newly built packages into the local release repo"
@@ -14,32 +15,35 @@ info:
 
 buildrpm:
 ifndef VERSION
-	$(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/privacyidea/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
-	@echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
+        $(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/privacyidea/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
+        @echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
 endif
-	PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea.spec
-	PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-server.spec
+        PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea.spec
+        PI_VERSION=${VERSION} rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-server.spec
 
 buildradius:
 ifndef VERSION
-	$(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/FreeRADIUS/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
-	@echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
+        $(eval VERSION := $(shell curl --silent https://api.github.com/repos/privacyidea/FreeRADIUS/tags | head | grep -Po '"name": "v?\K.*?(?=")' ))
+        @echo "Warning: VERSION not set. Using the latest tag from GitHub: $(VERSION)"
 endif
-	PI_VERSION=$(VERSION) rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-radius.spec
+        PI_VERSION=$(VERSION) rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-radius.spec
 
 buildselinux:
 	rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-selinux.spec
 
+buildpamselinux:
+	rpmbuild --define "_topdir `pwd`" -ba SPECS/privacyidea-pam-selinux.spec
+
 signrpm: buildrpm
-	find RPMS/ -name *.rpm -exec 'rpmsign' '--addsign' '{}' ';'
+        find RPMS/ -name *.rpm -exec 'rpmsign' '--addsign' '{}' ';'
 
 fill-release-repo: signrpm
-	mkdir -p repository/centos/$(OS)/
-	cp -r RPMS/* repository/centos/$(OS)/
+        mkdir -p repository/centos/$(OS)/
+        cp -r RPMS/* repository/centos/$(OS)/
 
 fill-devel-repo: signrpm
-	mkdir -p repository/centos-devel/$(OS)/
-	cp -r RPMS/* repository/centos-devel/$(OS)/
+        mkdir -p repository/centos-devel/$(OS)/
+        cp -r RPMS/* repository/centos-devel/$(OS)/
 
 make-repo:
 	# Fetch old packages
@@ -51,8 +55,8 @@ make-repo:
 	(cd repository/centos-devel/$(OS)/noarch/; createrepo .)
 
 push-repo:
-	(cd repository;	rsync -vr centos root@lancelot:/srv/www/rpmrepo/)
-	(cd repository;	rsync -vr centos-devel root@lancelot:/srv/www/rpmrepo/)
+	(cd repository; rsync -vr centos root@lancelot:/srv/www/rpmrepo/)
+	(cd repository; rsync -vr centos-devel root@lancelot:/srv/www/rpmrepo/)
 
 clean:
 	rm -fr repository

--- a/SOURCES/privacyidea-pam-selinux-src/Makefile
+++ b/SOURCES/privacyidea-pam-selinux-src/Makefile
@@ -1,0 +1,15 @@
+TARGETS?= privacyidea-pam-selinux
+MODULES?=${TARGETS:=.pp.bz2}
+
+all: ${TARGETS:=.pp.bz2}
+
+%.pp.bz2: %.pp
+	@echo Compressing $^ -\ $@
+	bzip2 -9 $^
+
+%.pp: %.te 
+	make -f /usr/share/selinux/devel/Makefile $@
+
+clean:
+	rm -f *~ *.tc *.pp *.pp.bz2
+	rm -rf tmp

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.fc
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.fc
@@ -1,0 +1,4 @@
+# Dateikontext für pam_privacyidea.so
+
+/usr/lib64/security/pam_privacyidea.so    --    system_u:object_r:admin_home_t:s0
+/dev/dm-0                                 --    system_u:object_r:admin_home_t:s0

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.fc
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.fc
@@ -1,4 +1,3 @@
-# file context for pam_privacyidea.so
-
+# file context for pam_privacyidea.so and pam.txt (offline token)
 /usr/lib64/security/pam_privacyidea.so    --    system_u:object_r:admin_home_t:s0
-/dev/dm-0                                 --    system_u:object_r:admin_home_t:s0
+/etc/privacyidea/pam.txt -- system_u:object_r:etc_t:s0

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.fc
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.fc
@@ -1,4 +1,4 @@
-# Dateikontext für pam_privacyidea.so
+# file context for pam_privacyidea.so
 
 /usr/lib64/security/pam_privacyidea.so    --    system_u:object_r:admin_home_t:s0
 /dev/dm-0                                 --    system_u:object_r:admin_home_t:s0

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.if
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.if
@@ -1,4 +1,3 @@
-# Schnittstelle für pam_privacyidea.so
-
+# interface for pam_privacyidea.so
 type pam_privacyidea, file_type;
 type pam_privacyidea, tcp_socket;

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.if
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.if
@@ -1,0 +1,4 @@
+# Schnittstelle für pam_privacyidea.so
+
+type pam_privacyidea, file_type;
+type pam_privacyidea, tcp_socket;

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
@@ -1,16 +1,21 @@
-# type enforcement rules for pam_privacyidea.so
+# Type Enforcement-Regeln für pam_privacyidea.so
+
 module privacyidea-pam-selinux 1.0;
 
 require {
     type admin_home_t;
+    type etc_t;
     type sshd_t;
     type http_port_t;
-    class file { read getattr open };
+    class file { read getattr open create write };
     class tcp_socket name_connect;
 }
 
-# Rule 1: Allow the process with type "sshd_t" to read and open the file "pam_privacyidea.so" with context "admin_home_t".
+# Regel 1: Erlaube dem Prozess mit dem Typ "sshd_t", die Datei "pam_privacyidea.so" mit dem Kontext "admin_home_t" zu lesen und zu öffnen.
 allow sshd_t admin_home_t:file { read getattr open };
 
-# Rule 2: Allow the process with type "sshd_t" to connect to TCP port 443 (http_port_t).
+# Regel 2: Erlaube dem Prozess mit dem Typ "sshd_t" eine Verbindung zum TCP-Port 443 (http_port_t) herzustellen.
 allow sshd_t http_port_t:tcp_socket name_connect;
+
+# Rule 3: Allow the process with type "sshd_t" to read and open the file "pam.txt" with context "etc_t".
+allow sshd_t etc_t:file { read open create write };

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
@@ -1,0 +1,18 @@
+# Type Enforcement-Regeln für pam_privacyidea.so
+
+module privacyidea-pam-selinux 1.0;
+
+require {
+    type admin_home_t;
+    type sshd_t;
+    type http_port_t;
+    class file { read getattr open };
+    class tcp_socket name_connect;
+}
+
+# Regel 1: Erlaube dem Prozess mit dem Typ "sshd_t", die Datei "pam_privacyidea.so" mit dem Kontext "admin_home_t" zu lesen und zu öffnen.
+
+allow sshd_t admin_home_t:file { read getattr open };
+
+# Regel 2: Erlaube dem Prozess mit dem Typ "sshd_t" eine Verbindung zum TCP-Port 443 (http_port_t) herzustellen.
+allow sshd_t http_port_t:tcp_socket name_connect;

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
@@ -1,5 +1,4 @@
-# Type Enforcement-Regeln für pam_privacyidea.so
-
+# type enforcement rules for pam_privacyidea.so
 module privacyidea-pam-selinux 1.0;
 
 require {
@@ -10,9 +9,8 @@ require {
     class tcp_socket name_connect;
 }
 
-# Regel 1: Erlaube dem Prozess mit dem Typ "sshd_t", die Datei "pam_privacyidea.so" mit dem Kontext "admin_home_t" zu lesen und zu öffnen.
-
+# Rule 1: Allow the process with type "sshd_t" to read and open the file "pam_privacyidea.so" with context "admin_home_t".
 allow sshd_t admin_home_t:file { read getattr open };
 
-# Regel 2: Erlaube dem Prozess mit dem Typ "sshd_t" eine Verbindung zum TCP-Port 443 (http_port_t) herzustellen.
+# Rule 2: Allow the process with type "sshd_t" to connect to TCP port 443 (http_port_t).
 allow sshd_t http_port_t:tcp_socket name_connect;

--- a/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
+++ b/SOURCES/privacyidea-pam-selinux-src/privacyidea-pam-selinux.te
@@ -11,10 +11,10 @@ require {
     class tcp_socket name_connect;
 }
 
-# Regel 1: Erlaube dem Prozess mit dem Typ "sshd_t", die Datei "pam_privacyidea.so" mit dem Kontext "admin_home_t" zu lesen und zu öffnen.
+# Rule 1: Allow the process with type "sshd_t" to read and open the file "pam_privacyidea.so" with context "admin_home_t".
 allow sshd_t admin_home_t:file { read getattr open };
 
-# Regel 2: Erlaube dem Prozess mit dem Typ "sshd_t" eine Verbindung zum TCP-Port 443 (http_port_t) herzustellen.
+# Rule 2: Allow the process with type "sshd_t" to connect to TCP port 443 (http_port_t).
 allow sshd_t http_port_t:tcp_socket name_connect;
 
 # Rule 3: Allow the process with type "sshd_t" to read and open the file "pam.txt" with context "etc_t".

--- a/SPECS/privacyidea-pam-selinux.spec
+++ b/SPECS/privacyidea-pam-selinux.spec
@@ -1,31 +1,30 @@
 %global selinuxtype	targeted
 %global moduletype	services
-%global modulenames	privacyidea-selinux	
-%define release 3
+%global modulenames	privacyidea-pam-selinux
+%define release 1
 
 # Usage: _format var format
 # Expand 'modulenames' into various formats as needed
 # Format must contain '$x' somewhere to do anything useful
-%global _format() export %1=""; for x in %{modulenames}; do %1+="%2 "; done;
+%global _format() export %1=""; for x in %{modulenames}; do %1+=%2; %1+=" "; done;
 
 # Package information
-Name:			privacyidea-selinux
+Name:			privacyidea-pam-selinux
 Version:		1.0	
 Release:		%{release}%{?dist}
 License:		GPLv2
 Group:			System Environment/Base
-Summary:		SELinux Policy for privacyidea privacyidea-server 
+Summary:		SELinux Policy for pam-privacyidea.so module 
 BuildArch:		noarch
 URL:			https://privacyidea.org
 Requires(post):		selinux-policy-base >= %{selinux_policyver}, selinux-policy-targeted >= %{selinux_policyver}, policycoreutils, libselinux-utils
 BuildRequires:		selinux-policy selinux-policy-devel
-Source1:		privacyidea-selinux-src
+Source1:		privacyidea-pam-selinux-src
 
 %description
-privacyidea-selinux provides a SELinux polices module
-for using with the privacyidea/ privacyidea-server packages
-based on Centos OS, that allows httpd service
-communicate with the services mysql and ldap
+privacyidea-pam-selinux provides an SELinux policy module
+for use with the privacyIDEA server that allows the pam module 
+to communicate correctly with the privacyIDEA sever.
 
 %prep
 rm -rf %{_builddir}/%{name}-%{version}
@@ -61,7 +60,7 @@ install -m 0644 $MODULES %{buildroot}%{_datadir}/selinux/packages
 
 %postun
 # Uninstall module
-[[ $1 -eq 0 ]] && %selinux_modules_uninstall -s %{selinuxtype} privacyidea-selinux
+[[ $1 -eq 0 ]] && %selinux_modules_uninstall -s %{selinuxtype} privacyidea-pam-selinux
 [[ -e /var/log/privacyidea ]] && restorecon -R -v /var/log/privacyidea > /dev/null 2>&1
 
 %posttrans
@@ -69,7 +68,6 @@ install -m 0644 $MODULES %{buildroot}%{_datadir}/selinux/packages
 
 %clean
 rm -rf %{_builddir}
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(0644,root,root,0755)
@@ -77,5 +75,5 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/selinux/devel/include/%{moduletype}/*.if
 
 %changelog
-* Fri Jun 19 2020 Julio Storch <julio.storch@netknights.it> - 1.0.0-1
-- SElinux Build release
+* Tue Sep 26 2023 Julio Storch <julio.storch@netknights.it> - 1.0.0-1
+- SElinux PAM build release

--- a/SPECS/privacyidea-server.spec
+++ b/SPECS/privacyidea-server.spec
@@ -16,7 +16,7 @@ Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 ExclusiveArch:  x86_64
 
 Requires:       privacyidea = %{version}, mariadb-server, httpd, mod_ssl, shadow-utils, rng-tools
-Requires:       python3-mod_wsgi
+Requires:       python39-mod_wsgi, python39
 
 Source1: pi.cfg
 Source2: privacyideaapp.wsgi

--- a/SPECS/privacyidea-server.spec
+++ b/SPECS/privacyidea-server.spec
@@ -16,7 +16,11 @@ Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
 ExclusiveArch:  x86_64
 
 Requires:       privacyidea = %{version}, mariadb-server, httpd, mod_ssl, shadow-utils, rng-tools
-Requires:       python39-mod_wsgi, python39
+%if 0%{?rhel} < 9
+Requires: python39-mod_wsgi, python39
+%else
+Requires: python3-mod_wsgi
+%endif
 
 Source1: pi.cfg
 Source2: privacyideaapp.wsgi

--- a/SPECS/privacyidea.spec
+++ b/SPECS/privacyidea.spec
@@ -44,8 +44,11 @@ mkdir -p %{_tmp_build_dir}
 git clone --recurse-submodules --branch v%{version} --depth 1 https://github.com/privacyidea/privacyidea.git %{_tmp_build_dir}/privacyidea
 
 %build
+%if %{rhel} < 9
 python3.9 -m venv /opt/privacyidea
-#virtualenv /opt/privacyidea
+%else
+python3 -m venv /opt/privacyidea
+%endif
 
 source /opt/privacyidea/bin/activate
 pip install --upgrade pip setuptools

--- a/SPECS/privacyidea.spec
+++ b/SPECS/privacyidea.spec
@@ -3,6 +3,7 @@
 %define version %{getenv:PI_VERSION}
 %define unmangled_version %{version}
 %define release 1
+%undefine __brp_mangle_shebangs
 # Somehow stripping the '.comment' section from the Pillow libraries breaks the strip-tool,
 # so we skip stripping and byte-compile in the postinstall scripts, otherwise Pillow will fail.
 %global __os_install_post %(echo '%{__os_install_post}' | sed -re 's!/usr/lib[^[:space:]]*/((brp-python-bytecompile)|(brp-strip-comment-note))[[:space:]].*$!!g')
@@ -18,15 +19,10 @@ Summary:        two-factor authentication system e.g. for OTP devices
 Group:          Applications/System
 License:        AGPLv3
 URL:            https://www.privacyidea.org
-Packager:       Cornelius Kölbel <cornelius.koelbel@netknights.it>
+Packager:       NetKnights GmbH <release@netknights.it>
 ExclusiveArch:  x86_64
 AutoReqProv:    no
-
-%if 0%{centos_ver} == 7
-BuildRequires: python-virtualenv, git
-%else
-BuildRequires: python3-virtualenv, git
-%endif
+BuildRequires:  python3-virtualenv, git
 
 %description
  privacyIDEA: identity, multifactor authentication, authorization.
@@ -48,11 +44,8 @@ mkdir -p %{_tmp_build_dir}
 git clone --recurse-submodules --branch v%{version} --depth 1 https://github.com/privacyidea/privacyidea.git %{_tmp_build_dir}/privacyidea
 
 %build
-%if 0%{centos_ver} == 7
-virtualenv -p /usr/bin/python3 /opt/privacyidea
-%else
-virtualenv /opt/privacyidea
-%endif
+python3.9 -m venv /opt/privacyidea
+#virtualenv /opt/privacyidea
 
 source /opt/privacyidea/bin/activate
 pip install --upgrade pip setuptools


### PR DESCRIPTION
Rhel8 uses python 3.6.x by default, this will be upgraded to python 3.9.x.
Rhel9 comes with python 3.9.x by default.
Thus, the first Rhel9 based package will be built on python 3.9.x.

Rhel and Rhel based distrubutions can then use privacyIDEA on python 3.9.
