### PR TITLE
forward http to https

### DIFF
--- a/SOURCES/privacyidea.conf
+++ b/SOURCES/privacyidea.conf
@@ -40,3 +40,16 @@ CustomLog logs/ssl_request_log \
           "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
 </VirtualHost>
+
+# If you want to forward http request to https enable the
+# following virtual host.
+<VirtualHost _default_:80>
+        # This will enable the Rewrite capabilities
+        RewriteEngine On
+
+        # This checks to make sure the connection is not already HTTPS
+        RewriteCond %{HTTPS} !=on
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
In our Ubuntu package, we have a default configuration where we forward http to https.
This patch adds the redirection here, too.

This is a draft because I tested this on Rocky 9 only.